### PR TITLE
Add exclusions similar to Python-Apple-support

### DIFF
--- a/3.7.Dockerfile
+++ b/3.7.Dockerfile
@@ -198,10 +198,12 @@ RUN cd rubicon-java-${RUBICON_JAVA_VERSION} && \
 RUN mv rubicon-java-${RUBICON_JAVA_VERSION}/build/librubicon.so $JNI_LIBS
 RUN mkdir -p /opt/python-build/app/libs/ && mv rubicon-java-${RUBICON_JAVA_VERSION}/build/rubicon.jar $APPROOT/app/libs/
 
-# Create output artifacts.
+# Create rubicon.zip and pythonhome.zip for this CPU architecture, filtering
+# pythonhome.zip using pythonhome-excludes to remove the CPython test suite, etc.
 ENV ASSETS_DIR $APPROOT/app/src/main/assets/
 ARG COMPRESS_LEVEL
-RUN mkdir -p "$ASSETS_DIR" && cd "$PYTHON_INSTALL_DIR" && zip -$COMPRESS_LEVEL -q "$ASSETS_DIR"/pythonhome.${TARGET_ABI_SHORTNAME}.zip -r .
+ADD 3.7.pythonhome-excludes /opt/python-build/
+RUN mkdir -p "$ASSETS_DIR" && cd "$PYTHON_INSTALL_DIR" && zip -x@/opt/python-build/3.7.pythonhome-excludes -$COMPRESS_LEVEL -q "$ASSETS_DIR"/pythonhome.${TARGET_ABI_SHORTNAME}.zip -r .
 RUN cd rubicon-java-${RUBICON_JAVA_VERSION} && zip -$COMPRESS_LEVEL -q "$ASSETS_DIR"/rubicon.zip -r rubicon
 
 RUN apt-get update -qq && apt-get -qq install rsync

--- a/3.7.excludes
+++ b/3.7.excludes
@@ -5,15 +5,16 @@
 #
 # Examples:
 #
-# lib/*/libssl*
-# lib/*/libcrypto*
+# libs/*/libssl*
+# libs/*/libcrypto*
 #
-# These lines would remove OpenSSL. The first asterisk is needed
+# These lines would remove OpenSSL. The libs/ directory contains
+# JNI libraries for the Android app. The first asterisk is needed
 # to match the pattern in all Android ABIs. The second asterisk
 # is present for convenience, to avoid having to specify the full
 # OpenSSL library name.
 #
-# lib/*/*xz*
+# libs/*/*xz*
 #
 # This line would remove the "xz" compression library. This might
 # be appropriate if you don't use that compression format in your

--- a/3.7.excludes
+++ b/3.7.excludes
@@ -1,0 +1,20 @@
+# You can add patterns to this file to remove them
+# from the Python-Android-support.zip file. Note that
+# if you are removing files from the Python standard library,
+# you need to use the 3.7.pythohome-excludes file.
+#
+# Examples:
+#
+# lib/*/libssl*
+# lib/*/libcrypto*
+#
+# These lines would remove OpenSSL. The first asterisk is needed
+# to match the pattern in all Android ABIs. The second asterisk
+# is present for convenience, to avoid having to specify the full
+# OpenSSL library name.
+#
+# lib/*/*xz*
+#
+# This line would remove the "xz" compression library. This might
+# be appropriate if you don't use that compression format in your
+# code.

--- a/3.7.excludes
+++ b/3.7.excludes
@@ -1,7 +1,7 @@
 # You can add patterns to this file to remove them
 # from the Python-Android-support.zip file. Note that
 # if you are removing files from the Python standard library,
-# you need to use the 3.7.pythohome-excludes file.
+# you need to use the 3.7.pythonhome-excludes file.
 #
 # Examples:
 #

--- a/3.7.pythonhome-excludes
+++ b/3.7.pythonhome-excludes
@@ -1,0 +1,17 @@
+# This file is used by `zip -i@this_file` in `Dockerfile` on
+# each architecture to filter the Python standard library we
+# distribute.
+lib/python*/config-*
+lib/python*/ctypes/test/*
+lib/python*/curses/*
+lib/python*/distutils/tests/*
+lib/python*/ensurepip/*
+lib/python*/idlelib/*
+lib/python*/lib2to3/tests/*
+lib/python*/site-packages/*
+lib/python*/sqlite3/test/*
+lib/python*/test/*
+lib/python*/tkinter/*
+lib/python*/turtle.py
+lib/python*/turtledemo/*
+lib/python*/wsgiref/*

--- a/3.7.sh
+++ b/3.7.sh
@@ -190,7 +190,7 @@ function main() {
     # Make a ZIP file.
     fix_permissions
     pushd build/3.7/app > /dev/null
-    zip -r -"${COMPRESS_LEVEL}" "../../../dist/Python-3.7-Android-support${BUILD_TAG}.zip" .
+    zip -x@../../../3.7.excludes -r -"${COMPRESS_LEVEL}" "../../../dist/Python-3.7-Android-support${BUILD_TAG}.zip" .
     popd
 }
 


### PR DESCRIPTION
This implementation separates exclusions for the JNI libraries vs. the pythonhomes.

## Technical details

There are **two** exclusion files. One is used in the Dockerfile; the other is used in 3.7.sh.

## Testing performed

I did a build, and I validated that the CPython test suite is excluded from the build. This is the same list as what we use in Python-Apple-support, I believe, with the caveat that I have to prefix everything with `lib/python*` because I don't `cd lib/python3.7` in my build script, because I'm using this as CPython's `PYTHONHOME` and I think it needs to have a `lib/python3.7` directory around it for that to work smoothly.

There's more stuff I can exclude, but I wanted to get this far and submit a pull request; the rest I can come back for later.

I did a build, and I discovered that with this change, a helloworld app still launches properly. Screenshot below.

![image](https://user-images.githubusercontent.com/25457/82635469-1a3fdc00-9bb5-11ea-9984-b6835aa0131c.png)

