### PR TITLE
More aggressively remove files from Python stdlib

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ build
 dist
 .git
 .github
+tmp

--- a/3.7.pythonhome-excludes
+++ b/3.7.pythonhome-excludes
@@ -1,17 +1,51 @@
-# This file is used by `zip -i@this_file` in `Dockerfile` on
-# each architecture to filter the Python standard library we
-# distribute.
-lib/python*/config-*
+# This is a list of Python standard library path patterns
+# we exclude from the Python-Android-support ZIP file. It is 
+# used by `zip -i@this_file` in `Dockerfile` to filter the pythonhome.zip
+# we generate for each Android ABI.
+#
+# Remove standard library test suites.
 lib/python*/ctypes/test/*
-lib/python*/curses/*
 lib/python*/distutils/tests/*
-lib/python*/ensurepip/*
-lib/python*/idlelib/*
 lib/python*/lib2to3/tests/*
-lib/python*/site-packages/*
 lib/python*/sqlite3/test/*
 lib/python*/test/*
+# Remove compiled test and example modules.
+lib/python*/lib-dynload/_test*.so
+lib/python*/lib-dynload/_ctypes_test*.so
+lib/python*/lib-dynload/xxlimited*.so
+lib/python*/lib-dynload/_xxtestfuzz.so
+# Remove wsgiref web app module; it's unusual that mobile apps would
+# start a web app server with it.
+lib/python*/wsgiref/*
+# Remove command-line curses toolkit.
+lib/python*/curses/*
+# Remove config-* directory, which is used for compiling C extension modules.
+lib/python*/config-*
+# Remove ensurepip. If user code needs pip, it can add it to 
+lib/python*/ensurepip/*
+# Remove Tcl/Tk GUI code. We don't build against Tcl/Tk at the moment, so this
+# will not work.
+lib/python*/idlelib/*
 lib/python*/tkinter/*
 lib/python*/turtle.py
 lib/python*/turtledemo/*
-lib/python*/wsgiref/*
+# Remove lib/pkgconfig files. These are used for compiling C extension modules.
+lib/pkgconfig/*
+# Remove site-packages directory. The Android template unpacks user code and
+# dependencies to a different path.
+lib/python*/site-packages/*
+# Remove include/ directory, only useful for compiling C extension modules.
+include/*
+# Remove bin/ directory, which contains executables like 2to3
+# (not useful in the app) and python3, which could possibly be useful,
+# except Python-Android-support doesn't support launching Python as a
+# subprocess very well at the moment.
+bin/*
+# Remove share/ directory, which contains user documentation (man pages).
+share/*
+# Remove libpython.so from the stdlib package. We rely on the libpython.so
+# in the JNI libs directory instead.
+lib/libpython3*.so
+# Remove pyc files. These take up space, but since most stdlib modules are
+# never imported by user code, they mostly have no value.
+*/*.pyc


### PR DESCRIPTION
In addition, add `tmp` to `.dockerignore` so I can make
`tmp` directories willy-nilly without slowing Docker down.

I'm open to feedback on the specific exclusions. I'm hopeful to wrap up excluding things today, because testing the exclusions is a little annoying. :)

## Size impact

We're down to 63MB, as I understand things:

```bash
$ du -h dist/Python-3.7-Android-support.zip 
 63M	dist/Python-3.7-Android-support.zip
```

## Testing done

I rebuilt the Hello World app (Toga tutorial 2 with trivial modifications) with these changes. Here's a screenshot demonstrating that it works.

![image](https://user-images.githubusercontent.com/25457/82719183-3b5c0780-9c5d-11ea-97db-e421e8de4024.png)
