### PR TITLE
Add sha256sum of pythonhome.*.zip to filename

### DIFF
--- a/3.7.Dockerfile
+++ b/3.7.Dockerfile
@@ -204,6 +204,10 @@ ENV ASSETS_DIR $APPROOT/app/src/main/assets/
 ARG COMPRESS_LEVEL
 ADD 3.7.pythonhome-excludes /opt/python-build/
 RUN mkdir -p "$ASSETS_DIR" && cd "$PYTHON_INSTALL_DIR" && zip -x@/opt/python-build/3.7.pythonhome-excludes -$COMPRESS_LEVEL -q "$ASSETS_DIR"/pythonhome.${TARGET_ABI_SHORTNAME}.zip -r .
+# Rename the ZIP file to include its sha256sum. This enables fast, accurate
+# cache validation/invalidation when the ZIP file reaches the Android device.
+RUN sha256sum "$ASSETS_DIR"/pythonhome.${TARGET_ABI_SHORTNAME}.zip | cut -d' ' -f1 > /tmp/sum
+RUN mv "$ASSETS_DIR"/pythonhome.${TARGET_ABI_SHORTNAME}.zip "$ASSETS_DIR"/pythonhome.`cat /tmp/sum`.${TARGET_ABI_SHORTNAME}.zip
 RUN cd rubicon-java-${RUBICON_JAVA_VERSION} && zip -$COMPRESS_LEVEL -q "$ASSETS_DIR"/rubicon.zip -r rubicon
 
 RUN apt-get update -qq && apt-get -qq install rsync

--- a/3.7.sh
+++ b/3.7.sh
@@ -187,10 +187,12 @@ function main() {
         build_one_abi "$TARGET_ABI_SHORTNAME" "3.7" "$COMPRESS_LEVEL"
     done
 
-    # Make a ZIP file.
+    # Make a ZIP file, writing it first to `.tmp` so that we atomically clobber an
+    # existing ZIP file rather than attempt to merge the new contents with old.
     fix_permissions
     pushd build/3.7/app > /dev/null
-    zip -x@../../../3.7.excludes -r -"${COMPRESS_LEVEL}" "../../../dist/Python-3.7-Android-support${BUILD_TAG}.zip" .
+    zip -x@../../../3.7.excludes -r -"${COMPRESS_LEVEL}" "../../../dist/Python-3.7-Android-support${BUILD_TAG}.zip".tmp .
+    mv "../../../dist/Python-3.7-Android-support${BUILD_TAG}.zip".tmp "../../../dist/Python-3.7-Android-support${BUILD_TAG}.zip"
     popd
 }
 


### PR DESCRIPTION
See https://github.com/beeware/briefcase-android-gradle-template/pull/11

In addition, use a `*.tmp` filename while building the
support library to avoid merging new contents with old
contents.

Without this, if the pythonhome.*.zip files' hashes change,
the final Python-3.7-Android-support.zip file will contain
all hashes ever seen, rather than just the current hashes.

## Testing done

See https://github.com/beeware/briefcase-android-gradle-template/pull/11

Also, I validated that the `.tmp` trick is required by removing it. Upon build, I get multiple x86.zip files:

```
paulproteus@mac-mini:~/projects/beeware/Python-Android-support$ unzip -l dist/Python-3.7-Android-support.zip  | grep x86.zip
  6367954  2020-05-22 20:00   src/main/assets/pythonhome.x86.zip
  6367954  2020-05-29 00:38   src/main/assets/pythonhome.4d8852d041e83a4fc6b6daa7dc20ee2098f314786c7641318c722b7e5c001892.x86.zip
```

With the `.tmp` trick in this PR, the duplication doesn't happen.