### PR TITLE
Add a way to check for Python on Android to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,3 +26,7 @@ will then be backported into the supported Python releases. The dev branch will
 track the most recent supported version of Python (currently, Python 3.7).
 
 See the individual branches for usage instructions.
+
+To detect that Python is running on Android via this build, check for the
+existence of ``sys.getandroidapilevel``;
+`see further discussion. <https://github.com/beeware/Python-Android-support/issues/8>`__


### PR DESCRIPTION
See https://github.com/beeware/Python-Android-support/issues/8

I'm going to merge this because it's a tiny textual change that is I believe consistent with the discussion on #8. Figured I'd make it a pull request just to notify @freakboy3742 and also I'm happy to take post-merge feedback.