### PR TITLE
Store stdlib in its own folder within assets/

### DIFF
--- a/3.7.Dockerfile
+++ b/3.7.Dockerfile
@@ -203,11 +203,11 @@ RUN mkdir -p /opt/python-build/app/libs/ && mv rubicon-java-${RUBICON_JAVA_VERSI
 ENV ASSETS_DIR $APPROOT/app/src/main/assets/
 ARG COMPRESS_LEVEL
 ADD 3.7.pythonhome-excludes /opt/python-build/
-RUN mkdir -p "$ASSETS_DIR" && cd "$PYTHON_INSTALL_DIR" && zip -x@/opt/python-build/3.7.pythonhome-excludes -$COMPRESS_LEVEL -q "$ASSETS_DIR"/pythonhome.${TARGET_ABI_SHORTNAME}.zip -r .
+RUN mkdir -p "$ASSETS_DIR/stdlib" && cd "$PYTHON_INSTALL_DIR" && zip -x@/opt/python-build/3.7.pythonhome-excludes -$COMPRESS_LEVEL -q "$ASSETS_DIR"/stdlib/pythonhome.${TARGET_ABI_SHORTNAME}.zip -r .
 # Rename the ZIP file to include its sha256sum. This enables fast, accurate
 # cache validation/invalidation when the ZIP file reaches the Android device.
-RUN sha256sum "$ASSETS_DIR"/pythonhome.${TARGET_ABI_SHORTNAME}.zip | cut -d' ' -f1 > /tmp/sum
-RUN mv "$ASSETS_DIR"/pythonhome.${TARGET_ABI_SHORTNAME}.zip "$ASSETS_DIR"/pythonhome.`cat /tmp/sum`.${TARGET_ABI_SHORTNAME}.zip
+RUN sha256sum "$ASSETS_DIR"/stdlib/pythonhome.${TARGET_ABI_SHORTNAME}.zip | cut -d' ' -f1 > /tmp/sum
+RUN mv "$ASSETS_DIR"/stdlib/pythonhome.${TARGET_ABI_SHORTNAME}.zip "$ASSETS_DIR"/stdlib/pythonhome.`cat /tmp/sum`.${TARGET_ABI_SHORTNAME}.zip
 RUN cd rubicon-java-${RUBICON_JAVA_VERSION} && zip -$COMPRESS_LEVEL -q "$ASSETS_DIR"/rubicon.zip -r rubicon
 
 RUN apt-get update -qq && apt-get -qq install rsync


### PR DESCRIPTION
This way, when linearly searching for the stdlib, we don't ever
iterate across all assets.

## Compatibility note

This will be a hard incompatibility break for the current app template. That's OK with me (I'll have a PR out to fix that momentarily) but I just wanted to make that visible in case we should do something different.