### PR TITLE
Ship only the C & Java rubicon-java code

### DIFF
--- a/3.7.Dockerfile
+++ b/3.7.Dockerfile
@@ -190,7 +190,9 @@ RUN cd Python-3.7.6 && rm Lib/test/test_wsgiref.py
 RUN cd Python-3.7.6 && make install
 RUN cp -a $PYTHON_INSTALL_DIR/lib/libpython3.7m.so "$JNI_LIBS"
 
-# Download & install rubicon-java.
+# Download & install rubicon-java's Java & C parts. The *.py files in rubicon-java are
+# incorporated into apps via app dependency management and are ABI-independent since
+# they access the C library via `ctypes`.
 ARG RUBICON_JAVA_VERSION=0.2.0
 ADD downloads/v${RUBICON_JAVA_VERSION}.tar.gz .
 RUN cd rubicon-java-${RUBICON_JAVA_VERSION} && \
@@ -208,6 +210,5 @@ RUN mkdir -p "$ASSETS_DIR/stdlib" && cd "$PYTHON_INSTALL_DIR" && zip -x@/opt/pyt
 # cache validation/invalidation when the ZIP file reaches the Android device.
 RUN sha256sum "$ASSETS_DIR"/stdlib/pythonhome.${TARGET_ABI_SHORTNAME}.zip | cut -d' ' -f1 > /tmp/sum
 RUN mv "$ASSETS_DIR"/stdlib/pythonhome.${TARGET_ABI_SHORTNAME}.zip "$ASSETS_DIR"/stdlib/pythonhome.`cat /tmp/sum`.${TARGET_ABI_SHORTNAME}.zip
-RUN cd rubicon-java-${RUBICON_JAVA_VERSION} && zip -$COMPRESS_LEVEL -q "$ASSETS_DIR"/rubicon.zip -r rubicon
 
 RUN apt-get update -qq && apt-get -qq install rsync


### PR DESCRIPTION
This allows apps to extract the pure-Python rubicon-java
components from PyPI, etc.

Note that this **is compatible** with the current toga_android -- since toga_android already includes rubicon-java as a dependency in `install_requires`, this is peaceful to merge as-is right now. However, it is **not compatible** with the current briefcase-gradle-android-template!

## Testing performed

I did a local build of this package, and then I ran a hello world app against that support package. It launched properly and painted its widgets on the screen.

App code (`app.py`):

```
"""
My first application
"""
import asyncio
import toga
from toga.style import Pack
from toga.style.pack import COLUMN, ROW

# from rubicon.java.android_events import AndroidEventLoop


class HelloWorld(toga.App):
    def startup(self):
        async def hello_world_async():
            print("async hello from hello_world_async()")

        # loop = AndroidEventLoop()
        # asyncio.set_event_loop(loop)
        # loop.run_forever_cooperatively()

        # asyncio.ensure_future(hello_world_async())

        main_box = toga.Box(style=Pack(direction=COLUMN))

        name_label = toga.Label("Your name: ", style=Pack(padding=(0, 5)))
        self.name_input = toga.TextInput(style=Pack(flex=1))

        name_box = toga.Box(style=Pack(direction=ROW, padding=5))
        name_box.add(name_label)
        name_box.add(self.name_input)

        button = toga.Button(
            "Say Hello!", on_press=self.say_hello, style=Pack(padding=5)
        )

        main_box.add(name_box)
        main_box.add(button)

        self.main_window = toga.MainWindow(title=self.formal_name)
        self.main_window.content = main_box
        self.main_window.show()

    async def say_hello(self, widget):
        print("Hello", self.name_input.value)


def main():
    return HelloWorld()
```