### PR TITLE
Fix typo: t != n

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -156,7 +156,7 @@ function main() {
     local DEFAULT_COMPRESS_LEVEL="8"
     local COMPRESS_LEVEL="$DEFAULT_COMPRESS_LEVEL"
     local BUILD_NUMBER=""
-    while getopts ":v:a:t:z:" opt; do
+    while getopts ":v:a:n:z:" opt; do
         case "${opt}" in
             v) # process Python version
                 VERSIONS="$OPTARG"
@@ -164,7 +164,7 @@ function main() {
             a) # process Android ABIs
                 TARGET_ABIS="$OPTARG"
                 ;;
-            t) # set build version name, used in BUILD_TAG
+            n) # set build version name, used in BUILD_TAG
                 BUILD_NUMBER="${OPTARG}"
                 ;;
             z) # set compression level, passed to zip


### PR DESCRIPTION
Testing done: On my development machine, the build starts now.

```
$ bash main.sh -v 3.7 -n b5     
Building b5
Downloading compile-time dependencies.
Using OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz from downloads/
Using android-ndk-r20b-linux-x86_64.zip from downloads/
Using openssl-1.1.1f.tar.gz from downloads/
Using libffi-3.3.tar.gz from downloads/
Using xz-5.2.4.tar.gz from downloads/
Using bzip2-1.0.8.tar.gz from downloads/
Using sqlite3_3.11.0.orig.tar.xz from downloads/
Using rubicon-java-v0.2.0.tar.gz from downloads/
Downloading Python versions, as needed.
Using Python-3.7.6.tar.xz from downloads/
Starting Docker builds.
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
See 'docker run --help'.
```

Note that it actually tries to launch Docker (ignore the error that on my machine, Docker is currently not running).

This fixes the build failure in https://github.com/beeware/Python-Android-support/actions/runs/140511765 and https://github.com/beeware/Python-Android-support/actions/runs/140511763