### PR TITLE
Upgrade OpenSSL to 1.1.1g

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -226,7 +226,7 @@ Build ZIP file of Python resources for Android, including CPython compiled as a 
 
     echo 'Starting Docker builds.'
     for VERSION in ${VERSIONS//,/ } ; do
-        if [ "$VERSION" != "3.6" ] && [ "$VERSION" != "3.7" ] ) ; then
+        if [ "$VERSION" != "3.6" ] && [ "$VERSION" != "3.7" ] ; then
             echo "Invalid Python version: $VERSION"
             exit 1
         fi

--- a/main.sh
+++ b/main.sh
@@ -129,13 +129,18 @@ function download() {
     mkdir -p "$download_dir"
     curl -L "$url" -o "$full_filename_tmp"
     local OK="no"
-    shasum -a 256 "${full_filename_tmp}" | grep -q "$sha256" && OK="yes"
+    local actual_sha256=$(shasum -a 256 "${full_filename_tmp}")
+    echo $actual_sha256 | grep -q "$sha256" && OK="yes"
     if [ "$OK" = "yes" ] ; then
         mv "${full_filename_tmp}" "${full_filename}"
     else
         echo "Checksum mismatch while downloading $name <$url>"
+        echo "Expected: $sha256"
+        echo "     Got: $actual_sha256"
         echo ""
-        echo "Maybe your Internet connection got disconnected during the download. Please re-run the script."
+        echo "Maybe your Internet connection got disconnected during the download. Re-run"
+        echo "the script to re-download. If you're updating the version of this package"
+        echo "update the expected SHA in this script."
         echo "Partial file remains in: ${full_filename_tmp}"
         echo "Aborting."
         exit 1
@@ -153,8 +158,8 @@ fix_permissions() {
 function main() {
     # Interpret argv for settings; first, set defaults. For some settings, create
     # DEFAULT_* variables for inclusion into help output.
-    local DEFAULT_VERSIONS="3.6,3.7"
-    local VERSIONS="$DEFAULT_VERSIONS"
+    local DEFAULT_VERSION="3.7"
+    local VERSION="$DEFAULT_VERSION"
     local DEFAULT_TARGET_ABIS="x86,x86_64,armeabi-v7a,arm64-v8a"
     local TARGET_ABIS="$DEFAULT_TARGET_ABIS"
     local DEFAULT_COMPRESS_LEVEL="8"
@@ -163,7 +168,7 @@ function main() {
     while getopts ":v:a:n:z:" opt; do
         case "${opt}" in
             v) # process Python version
-                VERSIONS="$OPTARG"
+                VERSION="$OPTARG"
                 ;;
             a) # process Android ABIs
                 TARGET_ABIS="$OPTARG"
@@ -178,12 +183,12 @@ function main() {
                 echo "Invalid option: $OPTARG requires an argument" 1>&2
                 ;;
             \? )
-                echo "Usage: main.sh [-v versions] [-a ABIs] [-n build_number] [-z compression_level]
+                echo "Usage: main.sh [-v version] [-a ABIs] [-n build_number] [-z compression_level]
 
 Build ZIP file of Python resources for Android, including CPython compiled as a .so.
 
--v: Specify Python versions to build, separated by commas. For example: -v 3.6,3.7
-    Default: ${DEFAULT_VERSIONS}
+-v: Specify Python version to build. For example: -v 3.6
+    Default: ${DEFAULT_VERSION}
 
 -a: Specify Android ABIs to build, separated by commas. For example: -a x86,arm64-v8a
     Default: ${TARGET_ABIS}
@@ -215,42 +220,46 @@ Build ZIP file of Python resources for Android, including CPython compiled as a 
     download ndk "https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip" "8381c440fe61fcbb01e209211ac01b519cd6adf51ab1c2281d5daad6ca4c8c8c"
     download openssl "https://www.openssl.org/source/openssl-1.1.1g.tar.gz" "ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46"
     download libffi "https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz" "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056"
-    download xz "https://tukaani.org/xz/xz-5.2.4.tar.gz" "b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145"
+    download xz "https://tukaani.org/xz/xz-5.2.5.tar.gz" "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"
     download bzip2 "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz" "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
     download sqlite3 "http://archive.ubuntu.com/ubuntu/pool/main/s/sqlite3/sqlite3_3.11.0.orig.tar.xz" "79fb8800b8744337d5317270899a5a40612bb76f81517e131bf496c26b044490"
-    download rubicon-java "https://github.com/beeware/rubicon-java/archive/v0.2.0.tar.gz" "b0d3d9ad4988c2d0e6995e2cbec085a5ef49b15e1be0d325b6141fb90fccccf7"
+    download rubicon-java "https://github.com/beeware/rubicon-java/archive/v0.2.1.tar.gz" "a1d1c6edccbd75631a0c3cc129239e10f7b6d8f221a393b96fbdc83293636f8b"
 
-    echo "Downloading Python versions."
-    download "python-3.7" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz" "55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f"
-    download "python-3.6" "https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tar.xz" "0a833c398ac8cd7c5538f7232d8531afef943c60495c504484f308dac3af40de"
-
-    echo 'Starting Docker builds.'
-    for VERSION in ${VERSIONS//,/ } ; do
-        if [ "$VERSION" != "3.6" ] && [ "$VERSION" != "3.7" ] ; then
+    echo "Downloading Python version."
+    case "$VERSION" in
+        3.6)
+            download "python-3.6" "https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tar.xz" "0a833c398ac8cd7c5538f7232d8531afef943c60495c504484f308dac3af40de"
+            ;;
+        3.7)
+            download "python-3.7" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz" "55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f"
+            ;;
+        *)
             echo "Invalid Python version: $VERSION"
             exit 1
-        fi
+            ;;
+    esac
 
-        # Clear the build directory.
-        mkdir -p build
-        mkdir -p dist
-        fix_permissions
-        rm -rf ./build/"$VERSION"
-        mkdir -p build/"$VERSION"
+    echo 'Starting Docker builds.'
 
-        # Build each ABI.
-        for TARGET_ABI_SHORTNAME in ${TARGET_ABIS//,/ }; do
-            echo "Building Python $VERSION for $TARGET_ABI_SHORTNAME"
-            build_one_abi "$TARGET_ABI_SHORTNAME" "$VERSION" "$COMPRESS_LEVEL"
-        done
+    # Clear the build directory.
+    mkdir -p build
+    mkdir -p dist
+    fix_permissions
+    rm -rf ./build/"$VERSION"
+    mkdir -p build/"$VERSION"
 
-        # Make a ZIP file, writing it first to `.tmp` so that we atomically clobber an
-        # existing ZIP file rather than attempt to merge the new contents with old.
-        pushd build/"$VERSION"/app > /dev/null
-        zip -x@../../../excludes/all/excludes -r -"${COMPRESS_LEVEL}" "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip".tmp .
-        mv "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip".tmp "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip"
-        popd
+    # Build each ABI.
+    for TARGET_ABI_SHORTNAME in ${TARGET_ABIS//,/ }; do
+        echo "Building Python $VERSION for $TARGET_ABI_SHORTNAME"
+        build_one_abi "$TARGET_ABI_SHORTNAME" "$VERSION" "$COMPRESS_LEVEL"
     done
+
+    # Make a ZIP file, writing it first to `.tmp` so that we atomically clobber an
+    # existing ZIP file rather than attempt to merge the new contents with old.
+    pushd build/"$VERSION"/app > /dev/null
+    zip -x@../../../excludes/all/excludes -r -"${COMPRESS_LEVEL}" "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip".tmp .
+    mv "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip".tmp "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip"
+    popd
 }
 
 main "$@"


### PR DESCRIPTION
Also:

- Adjust download function in main.sh to take project name.

- Consume downloads in Dockerfile by project name, never referencing
  version string.

This allows future upgrades to be driven 100% by `main.sh` and to
require no changes in `python.Dockerfile`.

Note also that this is a net-line-removal PR. :D