### PR TITLE
Include includes in the support package.

### DIFF
--- a/excludes/all/pythonhome-excludes
+++ b/excludes/all/pythonhome-excludes
@@ -21,7 +21,7 @@ lib/python*/wsgiref/*
 lib/python*/curses/*
 # Remove config-* directory, which is used for compiling C extension modules.
 lib/python*/config-*
-# Remove ensurepip. If user code needs pip, it can add it to 
+# Remove ensurepip. If user code needs pip, it can add it to
 lib/python*/ensurepip/*
 # Remove Tcl/Tk GUI code. We don't build against Tcl/Tk at the moment, so this
 # will not work.

--- a/main.sh
+++ b/main.sh
@@ -104,8 +104,13 @@ function build_one_abi() {
         -f python.Dockerfile .
     # Extract the build artifacts we need to create our zip file.
     docker run -v "${PWD}"/build/"${PYTHON_VERSION}"/:/mnt/ --rm --entrypoint rsync "$TAG_NAME" -a /opt/python-build/approot/. /mnt/.
-    # Extract pyconfig.h for debugging ./configure strangeness.
-    docker run -v "${PWD}"/build/"${PYTHON_VERSION}"/:/mnt/ --rm --entrypoint rsync "$TAG_NAME" -a /opt/python-build/built/python/include/python"${PYTHON_SOVERSION}"/pyconfig.h /mnt/
+    # Extract header files
+    docker run -v "${PWD}"/build/"${PYTHON_VERSION}"/app/include/:/mnt/ --rm --entrypoint rsync "$TAG_NAME" -a /opt/python-build/built/python/include/ /mnt/
+
+    # Move pyconfig.h to a platform-specific name.
+    mv "${PWD}"/build/"${PYTHON_VERSION}"/app/include/python"${PYTHON_SOVERSION}"/pyconfig.h "${PWD}"/build/"${PYTHON_VERSION}"/app/include/python"${PYTHON_SOVERSION}"/pyconfig-${TARGET_ABI_SHORTNAME}.h
+    # Inject a platform-agnostic pyconfig.h wrapper.
+    cp "${PWD}/patches/all/pyconfig.h" "${PWD}"/build/"${PYTHON_VERSION}"/app/include/python"${PYTHON_SOVERSION}"/
     # Remove temporary local tag.
     docker rmi "$TAG_NAME" > /dev/null
     fix_permissions

--- a/patches/all/pyconfig.h
+++ b/patches/all/pyconfig.h
@@ -1,0 +1,15 @@
+#ifdef __arm__
+#include "pyconfig-armeabi-v7a.h"
+#endif
+
+#ifdef __arm64__
+#include "pyconfig-arm64-v8a.h"
+#endif
+
+#ifdef __i386__
+#include "pyconfig-x386.h"
+#endif
+
+#ifdef __x86_64__
+#include "pyconfig-x86_64.h"
+#endif

--- a/patches/all/pyconfig.h
+++ b/patches/all/pyconfig.h
@@ -1,15 +1,15 @@
+#ifdef __aarch64__
+#include "pyconfig-arm64-v8a.h"
+#endif
+
 #ifdef __arm__
 #include "pyconfig-armeabi-v7a.h"
 #endif
 
-#ifdef __arm64__
-#include "pyconfig-arm64-v8a.h"
+#ifdef __x86_64__
+#include "pyconfig-x86_64.h"
 #endif
 
 #ifdef __i386__
-#include "pyconfig-x386.h"
-#endif
-
-#ifdef __x86_64__
-#include "pyconfig-x86_64.h"
+#include "pyconfig-x86.h"
 #endif


### PR DESCRIPTION
In order to link against libPython, you need the headers. Include them in the support package.