### PR TITLE
Store SONAME in libpython3.*.so

### DIFF
--- a/python.Dockerfile
+++ b/python.Dockerfile
@@ -158,7 +158,6 @@ RUN cd python-src && LDFLAGS="$(pkg-config --libs-only-L libffi) $(pkg-config --
     --prefix="$PYTHON_INSTALL_DIR" \
     ac_cv_func_setuid=no ac_cv_func_seteuid=no ac_cv_func_setegid=no ac_cv_func_getresuid=no ac_cv_func_setresgid=no ac_cv_func_setgid=no ac_cv_func_sethostname=no ac_cv_func_setresuid=no ac_cv_func_setregid=no ac_cv_func_setreuid=no ac_cv_func_getresgid=no ac_cv_func_setregid=no ac_cv_func_clock_settime=no ac_cv_header_termios_h=no ac_cv_func_sendfile=no ac_cv_header_spawn_h=no ac_cv_func_posix_spawn=no \
     ac_cv_func_setlocale=no ac_cv_working_tzset=no ac_cv_member_struct_tm_tm_zone=no ac_cv_func_sched_setscheduler=no
-RUN bash
 # Override ./configure results to futher force Python not to use some libc calls that trigger blocked syscalls.
 # TODO(someday): See if HAVE_INITGROUPS has another way to disable it.
 RUN cd python-src && sed -i -E 's,#define (HAVE_CHROOT|HAVE_SETGROUPS|HAVE_INITGROUPS) 1,,' pyconfig.h


### PR DESCRIPTION
## Rationale

On Android, if you link something against a library (e.g., libpython3.7m.so), the platform needs the library to have its SONAME set.

Also remove a useless `RUN bash` line (oops).

## Testing performed

`patchelf --debug --print-soname libs/x86/libpython3.6m.so` now outputs:

```
$ patchelf --debug --print-soname libs/x86/libpython3.6m.so
Kernel page size is 4096 bytes
libpython3.6m.so
```

You might have to `brew install patchelf` to repro the test.

This may allow us to simplify some rubicon-java stuff. I'll look into that on no particular timeline.