### PR TITLE
Use the -y (--symlinks) option with zip to avoid duplicates.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -276,7 +276,7 @@ Build ZIP file of Python resources for Android, including CPython compiled as a 
     # Make a ZIP file, writing it first to `.tmp` so that we atomically clobber an
     # existing ZIP file rather than attempt to merge the new contents with old.
     pushd build/"$VERSION"/app > /dev/null
-    zip -x@../../../excludes/all/excludes -r -"${COMPRESS_LEVEL}" "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip".tmp .
+    zip -x@../../../excludes/all/excludes -y -r -"${COMPRESS_LEVEL}" "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip".tmp .
     mv "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip".tmp "../../../dist/Python-$VERSION-Android-support${BUILD_TAG}.zip"
     popd
 }


### PR DESCRIPTION
I found some duplicates in the APK output by briefcase:

```
(bee-venv) helloworld % unzip -l "android/gradle/Hello World/app/build/outputs/apk/debug/app-debug.apk" | sort -k1
   647820  01-01-1981 01:01   lib/armeabi-v7a/libssl.so
   647820  01-01-1981 01:01   lib/armeabi-v7a/libssl1.1.so
...
   746032  01-01-1981 01:01   lib/x86/libssl.so
   746032  01-01-1981 01:01   lib/x86/libssl1.1.so
...
   753312  01-01-1981 01:01   lib/arm64-v8a/libssl.so
   753312  01-01-1981 01:01   lib/arm64-v8a/libssl1.1.so
   770064  01-01-1981 01:01   lib/x86_64/libssl.so
   770064  01-01-1981 01:01   lib/x86_64/libssl1.1.so
...
  2733640  01-01-1981 01:01   lib/armeabi-v7a/libcrypto.so
  2733640  01-01-1981 01:01   lib/armeabi-v7a/libcrypto1.1.so
...
  3278428  01-01-1981 01:01   lib/x86/libcrypto.so
  3278428  01-01-1981 01:01   lib/x86/libcrypto1.1.so
  3413544  01-01-1981 01:01   lib/arm64-v8a/libcrypto.so
  3413544  01-01-1981 01:01   lib/arm64-v8a/libcrypto1.1.so
...
  3582328  01-01-1981 01:01   lib/x86_64/libcrypto.so
  3582328  01-01-1981 01:01   lib/x86_64/libcrypto1.1.so
```

These files are from Python-3.7-Android-support.b7.zip. I guess these were symbolic links originally (libcrypto.so → libcrypto1.1.so).

By default the zip command follows symbolic links instead of including the link itself, this behaviour is changed by the -y (--symlinks) option.

I hope someone can test this as I am not familiar enough with Docker.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
