### PR TITLE
Build without debugging information.

### DIFF
--- a/python.Dockerfile
+++ b/python.Dockerfile
@@ -42,7 +42,7 @@ ENV AR=$TOOLCHAIN/bin/$TOOLCHAIN_TRIPLE-ar \
     RANLIB=$TOOLCHAIN/bin/$TOOLCHAIN_TRIPLE-ranlib \
     STRIP=$TOOLCHAIN/bin/$TOOLCHAIN_TRIPLE-strip \
     READELF=$TOOLCHAIN/bin/$TOOLCHAIN_TRIPLE-readelf \
-    CFLAGS="-fPIC -Wall -O0 -g"
+    CFLAGS="-fPIC -Wall -Os" LDFLAGS="-Wl,-S"
 
 # We build sqlite using a tarball from Ubuntu. We need to patch config.sub & config.guess so
 # autoconf can accept our weird TOOLCHAIN_TRIPLE value. It requires tcl8.6-dev and build-essential

--- a/python.Dockerfile
+++ b/python.Dockerfile
@@ -42,7 +42,8 @@ ENV AR=$TOOLCHAIN/bin/llvm-ar \
     RANLIB=$TOOLCHAIN/bin/llvm-ranlib \
     STRIP=$TOOLCHAIN/bin/llvm-strip \
     READELF=$TOOLCHAIN/bin/llvm-readelf \
-    CFLAGS="-fPIC -Wall -Os" LDFLAGS="-Wl,-S"
+    CFLAGS="-fPIC -Wall -Os" \
+    LDFLAGS="-Wl,-S"
 
 # Set up a directory for logs.
 ENV LOGS_DIR=${BUILD_HOME}/logs/${TARGET_ABI_SHORTNAME}
@@ -168,7 +169,7 @@ ENV SYSROOT_LIB=${TOOLCHAIN}/sysroot/usr/lib/${TOOLCHAIN_TRIPLE}/${ANDROID_API_L
 ARG PYTHON_EXTRA_CONFIGURE_FLAGS
 ENV PYTHON_EXTRA_CONFIGURE_FLAGS $PYTHON_EXTRA_CONFIGURE_FLAGS
 # Call ./configure with enough parameters to work.
-RUN cd python-src && LDFLAGS="$(pkg-config --libs-only-L libffi) $(pkg-config --libs-only-L liblzma) -L${LIBBZ2_INSTALL_DIR}/lib -L$OPENSSL_INSTALL_DIR/lib" \
+RUN cd python-src && LDFLAGS="${LDFLAGS} $(pkg-config --libs-only-L libffi) $(pkg-config --libs-only-L liblzma) -L${LIBBZ2_INSTALL_DIR}/lib -L$OPENSSL_INSTALL_DIR/lib" \
     CFLAGS="${CFLAGS} -I${LIBBZ2_INSTALL_DIR}/include $(pkg-config --cflags-only-I libffi) $(pkg-config --cflags-only-I liblzma)" \
     ./configure \
     --host "$TOOLCHAIN_TRIPLE" \


### PR DESCRIPTION
This is very debatable (and experimental), but I think it's worth considering.

Building the Hello World example from the tutorial, and looking at the APK output by briefcase, the largest files in it are the pythonhome.*.zip files, followed by shared libraries (libpython.so, libcrypto.so, etc):

<details>
<summary>

    (bee-venv) helloworld % unzip -l "android/gradle/Hello World/app/build/outputs/apk/debug/app-debug.apk" | sort -k1 | tail -20
</summary>

```
  3278428  01-01-1981 01:01   lib/x86/libcrypto.so
  3278428  01-01-1981 01:01   lib/x86/libcrypto1.1.so
  3413544  01-01-1981 01:01   lib/arm64-v8a/libcrypto.so
  3413544  01-01-1981 01:01   lib/arm64-v8a/libcrypto1.1.so
  3560932  01-01-1981 01:01   lib/armeabi-v7a/libpython3.7m.so
  3582328  01-01-1981 01:01   lib/x86_64/libcrypto.so
  3582328  01-01-1981 01:01   lib/x86_64/libcrypto1.1.so
  3851688  01-01-1981 01:01   lib/x86/libpython3.7m.so
  3987728  01-01-1981 01:01   lib/x86_64/libpython3.7m.so
  4106136  01-01-1981 01:01   lib/arm64-v8a/libpython3.7m.so
  6271296  01-01-1981 01:01   assets/stdlib/pythonhome.56b34b3d874fa7ac28ea10eb02abe7fef59cea16a3bbc6c93b13b1b27c819135.x86_64.zip
  6271753  01-01-1981 01:01   assets/stdlib/pythonhome.bf700eacba6e522c594ec58363d2c7fa63cab0a7c7482267c89cbe0935b37e8b.armeabi-v7a.zip
  6370233  01-01-1981 01:01   assets/stdlib/pythonhome.1030e7d6de1924180e6db781b6485afc9739a2e36895086bfef7026ede186c20.x86.zip
  6516944  01-01-1981 01:01   assets/stdlib/pythonhome.f105a7dd85affb280fdfe3097537d8a0854fd2e4b22d4325a27c1426093df076.arm64-v8a.zip
```
</details>

Examining pythonhome.*.arm64-v8a.zip, the largest files in it are the compiled Python modules unicodedata.so, _decimal.so, and so on:

<details>
<summary>

    (bee-venv) % unzip -l "assets/stdlib/pythonhome.f105a7dd85affb280fdfe3097537d8a0854fd2e4b22d4325a27c1426093df076.arm64-v8a.zip" | sort -k1 | tail -20
</summary>

```
   222208  02-06-2021 00:55   lib/python3.7/distutils/command/wininst-10.0-amd64.exe
   224256  02-06-2021 00:55   lib/python3.7/distutils/command/wininst-9.0-amd64.exe
   228152  02-06-2021 00:54   lib/python3.7/lib-dynload/_datetime.cpython-37m.so
   228690  02-06-2021 00:55   lib/python3.7/_pydecimal.py
   241680  02-06-2021 00:54   lib/python3.7/lib-dynload/_sqlite3.cpython-37m.so
   272848  02-06-2021 00:54   lib/python3.7/lib-dynload/_ssl.cpython-37m.so
   293376  02-06-2021 00:54   lib/python3.7/lib-dynload/_pickle.cpython-37m.so
   311872  02-06-2021 00:55   lib/python3.7/lib-dynload/_codecs_jp.cpython-37m.so
   364064  02-06-2021 00:55   lib/python3.7/lib-dynload/_ctypes.cpython-37m.so
   458240  02-06-2021 00:55   lib/python3.7/distutils/command/wininst-14.0.exe
   587776  02-06-2021 00:55   lib/python3.7/distutils/command/wininst-14.0-amd64.exe
   634088  02-06-2021 00:54   lib/python3.7/lib-dynload/pyexpat.cpython-37m.so
   668389  02-06-2021 00:55   lib/python3.7/pydoc_data/topics.py
   824496  02-06-2021 00:55   lib/python3.7/lib-dynload/_decimal.cpython-37m.so
  1108328  02-06-2021 00:54   lib/python3.7/lib-dynload/unicodedata.cpython-37m.so
```
</details>

Currently, everything is built with debugging information (-g) and no optimization (-O0). This is really important to debug crashes, but also produces big binaries.

I think if there are bugs that cause crashes, they will be in packages rather than in CPython itself. I propose building without debugging information and optimizing for size.

I estimate a ~30% reduction in size of the APK based on my experiments with NumPy. Compiling just NumPy with -Os (and using the same unoptimized CPython), I get a 75% reduction in the size of NumPy's compiled modules (like numpy/core/_multiarray_umath.so) and a 30% total reduction in size of the APK.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
